### PR TITLE
add apple shenanigans

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,24 @@ jobs:
         with:
           go-version: '>=1.21.0'
 
+      - name: Import Apple Certificate
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          # Create keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -t 3600 -u build.keychain
+          
+          # Import certificate
+          echo "$APPLE_CERTIFICATE" | base64 --decode > certificate.p12
+          security import certificate.p12 -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+
       - name: Build for all platforms
         run: |
           platforms=("windows/amd64" "windows/386" "darwin/amd64" "darwin/arm64" "linux/amd64" "linux/386" "linux/arm64" "linux/arm")
@@ -31,14 +49,37 @@ jobs:
             fi
             echo "Building for $OS/$ARCH..."
             GOOS=$OS GOARCH=$ARCH go build -o "dist/vitals_${OS}_${ARCH}/$output_name" .
-            # Create archive
-            cd dist
-            if [ "$OS" = "windows" ]; then
-              zip -r "vitals_${OS}_${ARCH}.zip" "vitals_${OS}_${ARCH}"
-            else
+            
+            # Sign macOS binaries
+            if [ "$OS" = "darwin" ]; then
+              echo "Signing macOS binary for $ARCH..."
+              codesign --force -s "${{ secrets.APPLE_DEVELOPER_ID }}" --options runtime "dist/vitals_${OS}_${ARCH}/$output_name"
+              
+              # Create a ZIP for notarization
+              cd dist
+              ditto -c -k --keepParent "vitals_${OS}_${ARCH}" "vitals_${OS}_${ARCH}.zip"
+              
+              # Notarize the ZIP
+              xcrun notarytool submit "vitals_${OS}_${ARCH}.zip" \
+                --apple-id "${{ secrets.APPLE_ID }}" \
+                --password "${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}" \
+                --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+                --wait
+              
+              # Create the final archive
               tar -czf "vitals_${OS}_${ARCH}.tar.gz" "vitals_${OS}_${ARCH}"
+              rm "vitals_${OS}_${ARCH}.zip"
+              cd ..
+            else
+              # Create archive for non-macOS platforms
+              cd dist
+              if [ "$OS" = "windows" ]; then
+                zip -r "vitals_${OS}_${ARCH}.zip" "vitals_${OS}_${ARCH}"
+              else
+                tar -czf "vitals_${OS}_${ARCH}.tar.gz" "vitals_${OS}_${ARCH}"
+              fi
+              cd ..
             fi
-            cd ..
           done
 
       - name: Create Release


### PR DESCRIPTION
To make this work, you'll need to set up a few GitHub repository secrets. These are required for code signing and notarizing the macOS binaries:

APPLE_CERTIFICATE: Your Apple Developer certificate in base64 format
APPLE_CERTIFICATE_PASSWORD: The password for your certificate
KEYCHAIN_PASSWORD: Any password for a temporary keychain (can be random)
APPLE_DEVELOPER_ID: Your Apple Developer ID certificate name (like "Developer ID Application: Your Name (TEAM_ID)")
APPLE_ID: Your Apple ID email
APPLE_TEAM_ID: Your Apple Developer Team ID
APPLE_APP_SPECIFIC_PASSWORD: An app-specific password generated from your Apple ID account
You can get these credentials by:

Having an Apple Developer account
Creating a Developer ID certificate in your Apple Developer account
Generating an app-specific password in your Apple ID settings
